### PR TITLE
Escape XSLT attribute value templates in report context output

### DIFF
--- a/frameworks/xspec/src/compiler/generate-xspec-tests.xsl
+++ b/frameworks/xspec/src/compiler/generate-xspec-tests.xsl
@@ -414,6 +414,16 @@
   <text><xsl:value-of select="." /></text>
 </xsl:template>  
   
+<xsl:template match="node()" mode="test:create-xslt-generator">
+  <xsl:copy>
+    <xsl:apply-templates select="@* | node()" mode="#current"/>
+  </xsl:copy>
+</xsl:template>  
+
+<xsl:template match="@*" mode="test:create-xslt-generator">
+  <xsl:attribute name="{name()}" namespace="{namespace-uri()}"
+    select="replace(replace(., '\{', '{{'), '\}', '}}')" />
+</xsl:template>  
 
 <!-- *** x:compile *** -->
 <!-- Helper code for the tests -->


### PR DESCRIPTION
When XSpec scenario is e.g.

```xml
<x:scenario label="attribute value template">
  <x:context select="*">
    <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML">
      <mml:mfenced open="{" close="" separators="|">
```

Where the markup inside `x:context` has an attribute with a curly brace, the generated XSLT is invalid. When the XSpec is compiles into XSLT, the curly brace is correctly [escaped](https://github.com/xspec/oXygen-XML-editor-xspec-support/blob/master/frameworks/xspec/src/compiler/generate-xspec-tests.xsl#L447) in the `@select` attribute of the `x:context` element, but not in the children elements.

This PR fixes the `x:context` output in the report to correctly escape curly braces so that they are not interpreted as attribute value templates.

# Example

```xml
<?xml version="1.0" encoding="UTF-8"?>
<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec" stylesheet="identity.xsl">
  <x:scenario label="escape attribute value template">
    <x:context select="*">
      <foo bar="{" baz="}" qux="{}"/>
    </x:context>
    <x:expect label="identity" select="*">
      <foo bar="{" baz="}" qux="{}"/>
    </x:expect>
  </x:scenario>
</x:description>
```

```xml
<?xml version="1.0" encoding="UTF-8"?>
<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
  xmlns:xs="http://www.w3.org/2001/XMLSchema"
  exclude-result-prefixes="xs"
  version="2.0">
  
  <xsl:template match="*">
    <xsl:copy-of select="."/>
  </xsl:template>
  
</xsl:stylesheet>
```

